### PR TITLE
have sfdefault set ItalicFont and BoldItalicFont

### DIFF
--- a/tex/latex/raleway/raleway.sty
+++ b/tex/latex/raleway/raleway.sty
@@ -122,7 +122,10 @@
 	\ifraleway@sfdefault
 		\setsansfont
 			[ UprightFont    = *-\raleway@regstyle ,
-			  BoldFont       = *-\raleway@boldstyle ]
+			  ItalicFont     = *-\raleway@regstyle-Italic ,
+			  BoldFont       = *-\raleway@boldstyle ,
+			  BoldItalicFont = *-\raleway@boldstyle-Italic
+			]
 			{Raleway}
 	\fi
 	


### PR DESCRIPTION
sfdefault option now properly sets ItalicFont and BoldItalicFont for use with \sffamily.